### PR TITLE
[feature/14] 취향 목록 조회, 생성, 삭제 api 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 	id("org.springframework.boot") version "2.1.17.RELEASE"
 	id("io.spring.dependency-management") version "1.0.10.RELEASE"
+	id("org.jetbrains.kotlin.plugin.noarg") version "1.2.71"
 	kotlin("jvm") version "1.2.71"
 	kotlin("plugin.spring") version "1.2.71"
 }
+
+apply(plugin = "kotlin-jpa")
 
 group = "com.team-taste.personal-taste"
 version = "0.0.1-SNAPSHOT"
@@ -21,12 +24,12 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("io.github.microutils:kotlin-logging:1.7.6")
+	runtime("com.h2database:h2")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude(module = "junit")
 	}
 	testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
-	testImplementation("com.h2database:h2")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 	testImplementation("io.kotlintest:kotlintest-runner-junit5:3.3.3")
 	testImplementation("io.kotlintest:kotlintest-extensions-spring:3.3.3")

--- a/src/main/kotlin/personaltaste/controller/TasteController.kt
+++ b/src/main/kotlin/personaltaste/controller/TasteController.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.*
 import personaltaste.controller.model.taste.TasteCreateRequest
 import personaltaste.controller.model.taste.TasteFindMultiResponse
 import personaltaste.service.TasteFindService
-import personaltaste.service.TasteManageService
+import personaltaste.service.TasteWriteService
 
 /**
  * 취향 (Taste) 목록조회, 추가, 삭제
@@ -16,7 +16,7 @@ import personaltaste.service.TasteManageService
 @RequestMapping("/api/v1/tastes")
 class TasteController(
         private val tasteFindService: TasteFindService,
-        private val tasteManageService: TasteManageService
+        private val tasteWriteService: TasteWriteService
 ) {
 
     @GetMapping
@@ -31,7 +31,7 @@ class TasteController(
     fun create(
             @RequestBody tasteCreateRequest: TasteCreateRequest
     ) {
-        tasteManageService.create(tasteCreateRequest.taste)
+        tasteWriteService.create(tasteCreateRequest.taste)
     }
 
     @DeleteMapping("/{taste_id}")
@@ -39,7 +39,7 @@ class TasteController(
     fun delete(
             @PathVariable("taste_id") tasteId: Long
     ) {
-        tasteManageService.delete(tasteId)
+        tasteWriteService.delete(tasteId)
     }
 
 }

--- a/src/main/kotlin/personaltaste/controller/TasteController.kt
+++ b/src/main/kotlin/personaltaste/controller/TasteController.kt
@@ -2,8 +2,10 @@ package personaltaste.controller
 
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import personaltaste.controller.model.taste.TasteCreateRequest
 import personaltaste.controller.model.taste.TasteFindMultiResponse
 import personaltaste.service.TasteFindService
+import personaltaste.service.TasteManageService
 
 /**
  * 취향 (Taste) 목록조회, 추가, 삭제
@@ -13,7 +15,8 @@ import personaltaste.service.TasteFindService
 @RestController
 @RequestMapping("/api/v1/tastes")
 class TasteController(
-        private val tasteFindService: TasteFindService
+        private val tasteFindService: TasteFindService,
+        private val tasteManageService: TasteManageService
 ) {
 
     @GetMapping
@@ -21,6 +24,22 @@ class TasteController(
     fun findAll() : TasteFindMultiResponse {
         // todo paging
         return TasteFindMultiResponse.of(tasteFindService.findAllActive())
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(
+            @RequestBody tasteCreateRequest: TasteCreateRequest
+    ) {
+        tasteManageService.create(tasteCreateRequest.taste)
+    }
+
+    @DeleteMapping("/{taste_id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun delete(
+            @PathVariable("taste_id") tasteId: Long
+    ) {
+        tasteManageService.delete(tasteId)
     }
 
 }

--- a/src/main/kotlin/personaltaste/controller/TasteController.kt
+++ b/src/main/kotlin/personaltaste/controller/TasteController.kt
@@ -1,0 +1,26 @@
+package personaltaste.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import personaltaste.controller.model.taste.TasteFindMultiResponse
+import personaltaste.service.TasteFindService
+
+/**
+ * 취향 (Taste) 목록조회, 추가, 삭제
+ *
+ * @author seungmin
+ */
+@RestController
+@RequestMapping("/api/v1/tastes")
+class TasteController(
+        private val tasteFindService: TasteFindService
+) {
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    fun findAll() : TasteFindMultiResponse {
+        // todo paging
+        return TasteFindMultiResponse.of(tasteFindService.findAllActive())
+    }
+
+}

--- a/src/main/kotlin/personaltaste/controller/UserController.kt
+++ b/src/main/kotlin/personaltaste/controller/UserController.kt
@@ -27,8 +27,7 @@ class UserController(
     }
 
 
-    @DeleteMapping
-    @RequestMapping("/{user_id}")
+    @DeleteMapping("/{user_id}")
     @ResponseStatus(HttpStatus.OK)
     fun delete(
         @PathVariable("user_id") userId: Long

--- a/src/main/kotlin/personaltaste/controller/model/taste/TasteCreateRequest.kt
+++ b/src/main/kotlin/personaltaste/controller/model/taste/TasteCreateRequest.kt
@@ -1,0 +1,7 @@
+package personaltaste.controller.model.taste
+
+import personaltaste.service.model.taste.TasteCreate
+
+data class TasteCreateRequest(
+    val taste: TasteCreate
+)

--- a/src/main/kotlin/personaltaste/controller/model/taste/TasteFindMultiResponse.kt
+++ b/src/main/kotlin/personaltaste/controller/model/taste/TasteFindMultiResponse.kt
@@ -1,0 +1,21 @@
+package personaltaste.controller.model.taste
+
+import personaltaste.service.model.taste.TasteFind
+import java.io.Serializable
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+data class TasteFindMultiResponse(
+        val tastes: List<TasteFind>
+) : Serializable {
+    companion object {
+        fun of(tastes: List<TasteFind>): TasteFindMultiResponse {
+            return TasteFindMultiResponse(
+                    tastes = tastes
+            )
+        }
+    }
+}

--- a/src/main/kotlin/personaltaste/entity/Taste.kt
+++ b/src/main/kotlin/personaltaste/entity/Taste.kt
@@ -45,4 +45,10 @@ data class Taste(
         this.priority = other.priority
         other.priority = temp
     }
+
+    fun delete(): Taste {
+        this.status = TasteStatus.DELETE
+
+        return this
+    }
 }

--- a/src/main/kotlin/personaltaste/entity/User.kt
+++ b/src/main/kotlin/personaltaste/entity/User.kt
@@ -18,6 +18,7 @@ data class User(
 
         val age: Int,
 
+        @Enumerated(EnumType.STRING)
         val gender: UserGender,
 
         @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/personaltaste/repository/TasteRepository.kt
+++ b/src/main/kotlin/personaltaste/repository/TasteRepository.kt
@@ -2,6 +2,7 @@ package personaltaste.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import personaltaste.entity.Taste
+import personaltaste.entity.model.taste.TasteStatus
 
 /**
  *
@@ -9,4 +10,7 @@ import personaltaste.entity.Taste
  * @author seungmin
  */
 interface TasteRepository : JpaRepository<Taste, Long> {
+
+    fun findAllByStatusOrderByPriority(status: TasteStatus): List<Taste>
+
 }

--- a/src/main/kotlin/personaltaste/repository/TasteRepository.kt
+++ b/src/main/kotlin/personaltaste/repository/TasteRepository.kt
@@ -13,4 +13,5 @@ interface TasteRepository : JpaRepository<Taste, Long> {
 
     fun findAllByStatusOrderByPriority(status: TasteStatus): List<Taste>
 
+    fun existsByName(name: String) : Boolean
 }

--- a/src/main/kotlin/personaltaste/service/TasteFindService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteFindService.kt
@@ -1,0 +1,24 @@
+package personaltaste.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import personaltaste.entity.model.taste.TasteStatus
+import personaltaste.repository.TasteRepository
+import personaltaste.service.model.taste.TasteFind
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+@Service
+class TasteFindService(
+        private val tasteRepository: TasteRepository
+) {
+    @Transactional(readOnly = true)
+    fun findAllActive(): List<TasteFind> {
+        val tastes = tasteRepository.findAllByStatusOrderByPriority(TasteStatus.ACTIVE)
+
+        return tastes.map(TasteFind.Companion::ofOnlyActiveOption)
+    }
+}

--- a/src/main/kotlin/personaltaste/service/TasteManageService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteManageService.kt
@@ -1,0 +1,41 @@
+package personaltaste.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import personaltaste.repository.TasteRepository
+import org.springframework.transaction.annotation.Transactional
+import personaltaste.entity.Taste
+import personaltaste.exception.ExceptionCode
+import personaltaste.exception.PersonalTasteException
+import personaltaste.service.model.taste.TasteCreate
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+@Service
+class TasteManageService(
+        private val tasteRepository: TasteRepository
+) {
+
+    @Transactional
+    fun create(tasteCreate: TasteCreate): Taste {
+        if (checkExists(tasteCreate.name))
+            throw PersonalTasteException(ExceptionCode.INVALID_VALUE, "동일한 취향이 이미 생성되어 있습니다.")
+
+        return tasteRepository.save(tasteCreate.toTaste())
+    }
+
+    @Transactional
+    fun delete(tasteId: Long): Taste {
+        return tasteRepository.findByIdOrNull(tasteId)?.delete()
+                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "${tasteId}와 일치하는 Taste 가 존재하지 않습니다.")
+    }
+
+    private fun checkExists(name: String): Boolean {
+        return tasteRepository.existsByName(name)
+    }
+
+
+}

--- a/src/main/kotlin/personaltaste/service/TasteWriteService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteWriteService.kt
@@ -15,7 +15,7 @@ import personaltaste.service.model.taste.TasteCreate
  * @author seungmin
  */
 @Service
-class TasteManageService(
+class TasteWriteService(
         private val tasteRepository: TasteRepository
 ) {
 

--- a/src/main/kotlin/personaltaste/service/model/taste/TasteCreate.kt
+++ b/src/main/kotlin/personaltaste/service/model/taste/TasteCreate.kt
@@ -1,0 +1,20 @@
+package personaltaste.service.model.taste
+
+import personaltaste.entity.Taste
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+data class TasteCreate(
+        val name: String,
+        val priority: Int
+) {
+    fun toTaste(): Taste {
+        return Taste.of(
+                name = name,
+                priority = priority
+        )
+    }
+}

--- a/src/main/kotlin/personaltaste/service/model/taste/TasteFind.kt
+++ b/src/main/kotlin/personaltaste/service/model/taste/TasteFind.kt
@@ -1,0 +1,28 @@
+package personaltaste.service.model.taste
+
+import personaltaste.entity.Taste
+import personaltaste.entity.TasteOption
+import java.io.Serializable
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+data class TasteFind(
+        val id: Long,
+        val name: String,
+        val tasteOptions: List<TasteOptionFind>
+) : Serializable {
+    companion object {
+        fun ofOnlyActiveOption(taste: Taste): TasteFind {
+            return TasteFind(
+                    id = taste.id,
+                    name = taste.name,
+                    tasteOptions = taste.tasteOptions
+                            .filter(TasteOption::activeYn)
+                            .map(TasteOptionFind.Companion::of)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/personaltaste/service/model/taste/TasteOptionFind.kt
+++ b/src/main/kotlin/personaltaste/service/model/taste/TasteOptionFind.kt
@@ -1,0 +1,23 @@
+package personaltaste.service.model.taste
+
+import personaltaste.entity.TasteOption
+import java.io.Serializable
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+data class TasteOptionFind(
+        val id: Long,
+        val name: String
+) : Serializable {
+    companion object {
+        fun of(tasteOption: TasteOption): TasteOptionFind {
+            return TasteOptionFind(
+                    id = tasteOption.id,
+                    name = tasteOption.name
+            )
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
+spring.h2.console.enabled=true
 
+spring.datasource.url=jdbc:h2:mem:personal-taste
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create
+
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,10 @@
+INSERT INTO user (id, created_at, created_by, updated_at, updated_by, age, email, gender, name, password, status) values (1, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', 30, 'choising@gmail.com', 'MALE', 'seungmin', '12345678', 'ACTIVE');
+INSERT INTO user (id, created_at, created_by, updated_at, updated_by, age, email, gender, name, password, status) values (2, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', 30, 'dom@gmail.com', 'MALE', 'sehun', '12345678', 'ACTIVE');
+
+INSERT INTO taste (id, created_at, created_by, updated_at, updated_by, name, priority, status) values (1, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', 'sauce', 1, 'ACTIVE');
+INSERT INTO taste (id, created_at, created_by, updated_at, updated_by, name, priority, status) values (2, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', 'coke', 2, 'ACTIVE');
+
+INSERT INTO taste_option (id, created_at, created_by, updated_at, updated_by, active_yn, name, taste_id) values (1, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', true, 'dip', 1);
+INSERT INTO taste_option (id, created_at, created_by, updated_at, updated_by, active_yn, name, taste_id) values (2, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', true, 'pour', 1);
+INSERT INTO taste_option (id, created_at, created_by, updated_at, updated_by, active_yn, name, taste_id) values (3, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', true, 'coca', 2);
+INSERT INTO taste_option (id, created_at, created_by, updated_at, updated_by, active_yn, name, taste_id) values (4, CURRENT_TIMESTAMP(), 'SYSTEM', CURRENT_TIMESTAMP(), 'SYSTEM', true, 'pepsi', 2);

--- a/src/test/kotlin/personaltaste/controller/TasteControllerTest.kt
+++ b/src/test/kotlin/personaltaste/controller/TasteControllerTest.kt
@@ -19,7 +19,7 @@ import personaltaste.entity.Taste
 import personaltaste.exception.ExceptionCode
 import personaltaste.exception.PersonalTasteException
 import personaltaste.service.TasteFindService
-import personaltaste.service.TasteManageService
+import personaltaste.service.TasteWriteService
 import personaltaste.service.model.taste.TasteCreate
 import personaltaste.service.model.taste.TasteFind
 import support.test.BaseTest
@@ -35,7 +35,7 @@ class TasteControllerTest : BaseTest() {
     private lateinit var tasteFindService: TasteFindService
 
     @MockBean
-    private lateinit var tasteManageService: TasteManageService
+    private lateinit var tasteWriteService: TasteWriteService
 
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -87,7 +87,7 @@ class TasteControllerTest : BaseTest() {
                 priority = priority
         )
 
-        given(tasteManageService.create(tasteCreate)).willReturn(tasteCreate.toTaste())
+        given(tasteWriteService.create(tasteCreate)).willReturn(tasteCreate.toTaste())
 
         // when
         val result = mockMvc.perform(
@@ -116,7 +116,7 @@ class TasteControllerTest : BaseTest() {
                 priority = priority
         )
 
-        given(tasteManageService.create(tasteCreate)).willThrow(PersonalTasteException(ExceptionCode.INVALID_VALUE, "중복된 name 존재"))
+        given(tasteWriteService.create(tasteCreate)).willThrow(PersonalTasteException(ExceptionCode.INVALID_VALUE, "중복된 name 존재"))
 
         // when
         val result = mockMvc.perform(
@@ -149,7 +149,7 @@ class TasteControllerTest : BaseTest() {
                 priority = eatPriority
         )
 
-        given(tasteManageService.delete(eatId)).willReturn(eat.delete())
+        given(tasteWriteService.delete(eatId)).willReturn(eat.delete())
 
         // when
         val result = mockMvc.perform(
@@ -166,7 +166,7 @@ class TasteControllerTest : BaseTest() {
     fun `taste 삭제 실패`() {
         // given
         val eatId = 1L
-        given(tasteManageService.delete(eatId)).willThrow(PersonalTasteException(ExceptionCode.NOT_FOUND, "일치하는 Taste 가 존재하지 않습니다."))
+        given(tasteWriteService.delete(eatId)).willThrow(PersonalTasteException(ExceptionCode.NOT_FOUND, "일치하는 Taste 가 존재하지 않습니다."))
 
         // when
         val result = mockMvc.perform(

--- a/src/test/kotlin/personaltaste/controller/TasteControllerTest.kt
+++ b/src/test/kotlin/personaltaste/controller/TasteControllerTest.kt
@@ -1,0 +1,184 @@
+package personaltaste.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockitokotlin2.given
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import personaltaste.controller.model.taste.TasteCreateRequest
+import personaltaste.entity.Taste
+import personaltaste.exception.ExceptionCode
+import personaltaste.exception.PersonalTasteException
+import personaltaste.service.TasteFindService
+import personaltaste.service.TasteManageService
+import personaltaste.service.model.taste.TasteCreate
+import personaltaste.service.model.taste.TasteFind
+import support.test.BaseTest
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class TasteControllerTest : BaseTest() {
+
+    @Autowired
+    private lateinit var snakeCaseObjectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var tasteFindService: TasteFindService
+
+    @MockBean
+    private lateinit var tasteManageService: TasteManageService
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `taste 목록 조회 성공`() {
+        // given
+        val eatName = "먹기"
+        val eatPriority = 1
+
+        val mintChocolateName = "민초"
+        val mintChocolatePriority = 2
+
+        val eat = Taste.of(
+                name = eatName,
+                priority = eatPriority
+        )
+
+        val mintChocolate = Taste.of(
+                name = mintChocolateName,
+                priority = mintChocolatePriority
+        )
+
+        val tasteFindList = mutableListOf(TasteFind.ofOnlyActiveOption(mintChocolate), TasteFind.ofOnlyActiveOption(eat))
+
+        given(tasteFindService.findAllActive()).willReturn(tasteFindList)
+
+        // when
+        val result = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/v1/tastes")
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        )
+
+        // then
+        result
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("tastes[0].name").value(mintChocolateName))
+                .andExpect(jsonPath("tastes[1].name").value(eatName))
+    }
+
+    @Test
+    fun `taste 생성 성공`() {
+        // given
+        val name = "먹기"
+        val priority = 1
+        val tasteCreate = TasteCreate(
+                name = name,
+                priority = priority
+        )
+
+        given(tasteManageService.create(tasteCreate)).willReturn(tasteCreate.toTaste())
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/tastes")
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .content(
+                    snakeCaseObjectMapper.writeValueAsString(
+                        TasteCreateRequest(tasteCreate)
+                    )
+                )
+        )
+
+        // then
+        result
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isCreated)
+    }
+
+    @Test
+    fun `taste 생성 실패 (이미 name 등록 되어 있는 경우)`() {
+        // given
+        val name = "먹기"
+        val priority = 1
+        val tasteCreate = TasteCreate(
+                name = name,
+                priority = priority
+        )
+
+        given(tasteManageService.create(tasteCreate)).willThrow(PersonalTasteException(ExceptionCode.INVALID_VALUE, "중복된 name 존재"))
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/tastes")
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .content(
+                    snakeCaseObjectMapper.writeValueAsString(
+                        TasteCreateRequest(tasteCreate)
+                    )
+                )
+        )
+
+        // then
+        result
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.error_code", equalTo("INVALID_VALUE")))
+            .andExpect(jsonPath("$.error_message", equalTo("${ExceptionCode.INVALID_VALUE.message} 중복된 name 존재") ))
+    }
+
+    @Test
+    fun `taste 삭제 성공`() {
+        // given
+        val eatId = 1L
+        val eatName = "먹기"
+        val eatPriority = 1
+
+        val eat = Taste.of(
+                name = eatName,
+                priority = eatPriority
+        )
+
+        given(tasteManageService.delete(eatId)).willReturn(eat.delete())
+
+        // when
+        val result = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/v1/tastes/{taste_id}", eatId)
+        )
+
+        // then
+        result
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `taste 삭제 실패`() {
+        // given
+        val eatId = 1L
+        given(tasteManageService.delete(eatId)).willThrow(PersonalTasteException(ExceptionCode.NOT_FOUND, "일치하는 Taste 가 존재하지 않습니다."))
+
+        // when
+        val result = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/v1/tastes/{taste_id}", eatId)
+        )
+
+        // then
+        result
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isNotFound)
+                .andExpect(jsonPath("$.error_code", equalTo("NOT_FOUND")))
+                .andExpect(jsonPath("$.error_message", equalTo("${ExceptionCode.NOT_FOUND.message} 일치하는 Taste 가 존재하지 않습니다.") ))
+    }
+
+}

--- a/src/test/kotlin/personaltaste/controller/UserControllerTest.kt
+++ b/src/test/kotlin/personaltaste/controller/UserControllerTest.kt
@@ -95,7 +95,7 @@ class UserControllerTest : BaseTest() {
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.error_code", equalTo("INVALID_VALUE")))
-            .andExpect(jsonPath("$.error_message", equalTo("${ExceptionCode.INVALID_VALUE.message} 중복된 email 존") ))
+            .andExpect(jsonPath("$.error_message", equalTo("${ExceptionCode.INVALID_VALUE.message} 중복된 email 존재") ))
     }
 
     @Test

--- a/src/test/kotlin/personaltaste/service/TasteFindServiceTest.kt
+++ b/src/test/kotlin/personaltaste/service/TasteFindServiceTest.kt
@@ -1,0 +1,61 @@
+package personaltaste.service
+
+import com.nhaarman.mockitokotlin2.given
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import personaltaste.entity.Taste
+import personaltaste.entity.model.taste.TasteStatus
+import personaltaste.repository.TasteRepository
+import personaltaste.service.model.taste.TasteFind
+import support.test.BaseTest
+
+/**
+ * @author seungmin
+ */
+@SpringBootTest(classes = [TasteFindService::class])
+class TasteFindServiceTest: BaseTest() {
+
+    @MockBean
+    private lateinit var tasteRepository: TasteRepository
+
+    @Autowired
+    private lateinit var tasteFindService: TasteFindService
+
+    @Test
+    fun `findAll test`() {
+        // given
+        val eatName = "먹기"
+        val eatPriority = 1
+
+        val mintChocolateName = "민초"
+        val mintChocolatePriority = 2
+
+        val eat = Taste.of(
+                name = eatName,
+                priority = eatPriority
+        )
+
+        val mintChocolate = Taste.of(
+                name = mintChocolateName,
+                priority = mintChocolatePriority
+        )
+
+        val tasteList = mutableListOf(mintChocolate, eat)
+
+        val tasteFindEat = TasteFind.ofOnlyActiveOption(eat)
+        val tasteFindMintChocolate = TasteFind.ofOnlyActiveOption(mintChocolate)
+
+        val tasteFindList = mutableListOf(tasteFindMintChocolate, tasteFindEat)
+
+        given(tasteRepository.findAllByStatusOrderByPriority(TasteStatus.ACTIVE)).willReturn(tasteList)
+
+        // when
+        val result = tasteFindService.findAllActive()
+
+        // then
+        result shouldBe tasteFindList
+    }
+}

--- a/src/test/kotlin/personaltaste/service/TasteManageServiceTest.kt
+++ b/src/test/kotlin/personaltaste/service/TasteManageServiceTest.kt
@@ -7,10 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import personaltaste.entity.Taste
-import personaltaste.entity.User
 import personaltaste.entity.model.taste.TasteStatus
-import personaltaste.entity.model.user.UserGender
-import personaltaste.entity.model.user.UserStatus
 import personaltaste.repository.TasteRepository
 import personaltaste.service.model.taste.TasteCreate
 import support.test.BaseTest
@@ -19,14 +16,14 @@ import java.util.*
 /**
  * @author seungmin
  */
-@SpringBootTest(classes = [TasteManageService::class])
+@SpringBootTest(classes = [TasteWriteService::class])
 class TasteManageServiceTest: BaseTest() {
 
     @MockBean
     private lateinit var tasteRepository: TasteRepository
 
     @Autowired
-    private lateinit var tasteManageService: TasteManageService
+    private lateinit var tasteWriteService: TasteWriteService
 
     @Test
     fun `create test`() {
@@ -44,7 +41,7 @@ class TasteManageServiceTest: BaseTest() {
         given(tasteRepository.save(taste)).willReturn(taste)
 
         // when
-        val result = tasteManageService.create(tasteCreate)
+        val result = tasteWriteService.create(tasteCreate)
 
         // then
         result shouldBe taste
@@ -65,7 +62,7 @@ class TasteManageServiceTest: BaseTest() {
         given(tasteRepository.findById(eatId)).willReturn(Optional.of(eat))
 
         // when
-        val result = tasteManageService.delete(eatId)
+        val result = tasteWriteService.delete(eatId)
 
         // then
         result.status shouldBe TasteStatus.DELETE

--- a/src/test/kotlin/personaltaste/service/TasteManageServiceTest.kt
+++ b/src/test/kotlin/personaltaste/service/TasteManageServiceTest.kt
@@ -1,0 +1,73 @@
+package personaltaste.service
+
+import com.nhaarman.mockitokotlin2.given
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import personaltaste.entity.Taste
+import personaltaste.entity.User
+import personaltaste.entity.model.taste.TasteStatus
+import personaltaste.entity.model.user.UserGender
+import personaltaste.entity.model.user.UserStatus
+import personaltaste.repository.TasteRepository
+import personaltaste.service.model.taste.TasteCreate
+import support.test.BaseTest
+import java.util.*
+
+/**
+ * @author seungmin
+ */
+@SpringBootTest(classes = [TasteManageService::class])
+class TasteManageServiceTest: BaseTest() {
+
+    @MockBean
+    private lateinit var tasteRepository: TasteRepository
+
+    @Autowired
+    private lateinit var tasteManageService: TasteManageService
+
+    @Test
+    fun `create test`() {
+        // given
+        val name = "먹기"
+        val priority = 1
+        val tasteCreate = TasteCreate(
+                name = name,
+                priority = priority
+        )
+
+        val taste = tasteCreate.toTaste()
+
+        given(tasteRepository.existsByName(name)).willReturn(false)
+        given(tasteRepository.save(taste)).willReturn(taste)
+
+        // when
+        val result = tasteManageService.create(tasteCreate)
+
+        // then
+        result shouldBe taste
+    }
+
+    @Test
+    fun `delete test`() {
+        // given
+        val eatId = 1L
+        val eatName = "먹기"
+        val eatPriority = 1
+
+        val eat = Taste.of(
+                name = eatName,
+                priority = eatPriority
+        )
+
+        given(tasteRepository.findById(eatId)).willReturn(Optional.of(eat))
+
+        // when
+        val result = tasteManageService.delete(eatId)
+
+        // then
+        result.status shouldBe TasteStatus.DELETE
+    }
+}


### PR DESCRIPTION
어렵다 어려워 코틀린 언어가 어색해서 확실히 시간이 걸리네

일단 dto 를 서비스 계층과 controller 계층에서 따로 쓰는게 신기했음. 좋은거 같아.

그리구 나는 Taste read 랑 write 서비스를 따로 쓰고 싶은데 (transaction read only 설정 때문도 있고)

이걸 general 한 경우에 {}FindService 랑 {}ManageService 로 할까 해서 일단 저렇게 나눠놨는데, 
그냥 인지하기 편하게 {}ReadOnlyService, {}WriteService 이런식으로 나누는게 나으려나? 어케생각함.

specific 한 경우에는 당연히 {}CreateService 이런식으로 쓰긴 할텐데 
저렇게 read/write 만을 목적으로 서비스계층 클래스를 분리하는 경우 네이밍이 어느정도 일관되면 좋을 것 같아서!


하 그리고

`TasteFindService` Class 에서 .map 쓴거랑

`TasteFind` Class 의 팩토리메소드 에서도 .filter 랑 .map 을 썼는데 kotlin 에서 첨써봐서

일단 내가 의도한대로 동작하긴 하는데 map { } 가 아닌 map() 를 쓰기도해서 맞는지 확인 한번만 부탁쓰