### PR TITLE
[feature/16] taset option api 구현

### DIFF
--- a/src/main/kotlin/personaltaste/controller/TasteController.kt
+++ b/src/main/kotlin/personaltaste/controller/TasteController.kt
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import personaltaste.controller.model.taste.TasteCreateRequest
 import personaltaste.controller.model.taste.TasteFindMultiResponse
+import personaltaste.controller.model.taste.TasteFindSingleResponse
 import personaltaste.service.TasteFindService
 import personaltaste.service.TasteWriteService
 
@@ -24,6 +25,12 @@ class TasteController(
     fun findAll() : TasteFindMultiResponse {
         // todo paging
         return TasteFindMultiResponse.of(tasteFindService.findAllActive())
+    }
+
+    @GetMapping("/{taste_id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun findOne(@PathVariable("taste_id") tasteId: Long) : TasteFindSingleResponse {
+        return TasteFindSingleResponse.of(tasteFindService.findOneActive(tasteId))
     }
 
     @PostMapping

--- a/src/main/kotlin/personaltaste/controller/TasteOptionController.kt
+++ b/src/main/kotlin/personaltaste/controller/TasteOptionController.kt
@@ -1,0 +1,36 @@
+package personaltaste.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import personaltaste.controller.model.taste.TasteOptionCreateRequest
+import personaltaste.service.TasteOptionWriteService
+
+/**
+ * 취향 Option(선택지) 목록 조회, 추가, 삭제
+ *
+ * @author seungmin
+ */
+@RestController
+@RequestMapping("/api/v1/tastes/{taste_id}/options")
+class TasteOptionController(
+        private val tasteOptionWriteService: TasteOptionWriteService
+) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(
+            @PathVariable("taste_id") tasteId: Long,
+            @RequestBody tasteOptionCreateRequest: TasteOptionCreateRequest
+    ) {
+        tasteOptionWriteService.create(tasteId, tasteOptionCreateRequest.name)
+    }
+
+    @DeleteMapping("/{taste_option_id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun delete(
+            @PathVariable("taste_id") tasteId: Long,
+            @PathVariable("taste_option_id") tasteOptionId: Long
+    ) {
+        tasteOptionWriteService.delete(tasteId, tasteOptionId)
+    }
+}

--- a/src/main/kotlin/personaltaste/controller/model/taste/TasteFindSingleResponse.kt
+++ b/src/main/kotlin/personaltaste/controller/model/taste/TasteFindSingleResponse.kt
@@ -1,0 +1,16 @@
+package personaltaste.controller.model.taste
+
+import personaltaste.service.model.taste.TasteFind
+import java.io.Serializable
+
+class TasteFindSingleResponse(
+        val taste: TasteFind
+) : Serializable {
+    companion object {
+        fun of(taste: TasteFind): TasteFindSingleResponse {
+            return TasteFindSingleResponse(
+                    taste = taste
+            )
+        }
+    }
+}

--- a/src/main/kotlin/personaltaste/controller/model/taste/TasteOptionCreateRequest.kt
+++ b/src/main/kotlin/personaltaste/controller/model/taste/TasteOptionCreateRequest.kt
@@ -1,0 +1,5 @@
+package personaltaste.controller.model.taste
+
+data class TasteOptionCreateRequest (
+    val name : String
+)

--- a/src/main/kotlin/personaltaste/entity/TasteOption.kt
+++ b/src/main/kotlin/personaltaste/entity/TasteOption.kt
@@ -34,7 +34,9 @@ data class TasteOption(
         }
     }
 
-    fun delete() {
+    fun delete() : TasteOption {
         this.activeYn = false
+
+        return this
     }
 }

--- a/src/main/kotlin/personaltaste/repository/TasteOptionRepository.kt
+++ b/src/main/kotlin/personaltaste/repository/TasteOptionRepository.kt
@@ -1,0 +1,17 @@
+package personaltaste.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import personaltaste.entity.Taste
+import personaltaste.entity.TasteOption
+
+/**
+ *
+ *
+ * @author seungmin
+ */
+interface TasteOptionRepository : JpaRepository<TasteOption, Long> {
+
+    fun existsByTasteAndName(taste: Taste, name: String): Boolean
+
+    fun findByIdAndTaste(id : Long, taste: Taste) : TasteOption?
+}

--- a/src/main/kotlin/personaltaste/repository/TasteRepository.kt
+++ b/src/main/kotlin/personaltaste/repository/TasteRepository.kt
@@ -13,5 +13,7 @@ interface TasteRepository : JpaRepository<Taste, Long> {
 
     fun findAllByStatusOrderByPriority(status: TasteStatus): List<Taste>
 
+    fun findByIdAndStatus(id : Long, status : TasteStatus) : Taste?
+
     fun existsByName(name: String) : Boolean
 }

--- a/src/main/kotlin/personaltaste/service/TasteFindService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteFindService.kt
@@ -2,6 +2,7 @@ package personaltaste.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import personaltaste.entity.Taste
 import personaltaste.entity.model.taste.TasteStatus
 import personaltaste.exception.ExceptionCode
 import personaltaste.exception.PersonalTasteException
@@ -27,9 +28,11 @@ class TasteFindService(
     }
 
     fun findOneActive(tasteId : Long) : TasteFind {
-        val taste = tasteRepository.findByIdAndStatus(tasteId, TasteStatus.ACTIVE)
-                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "${tasteId}에 맞는 취향이 존재하지 않습니다.")
+        return TasteFind.ofOnlyActiveOption(this.findOneActiveTaste(tasteId))
+    }
 
-        return TasteFind.ofOnlyActiveOption(taste)
+    fun findOneActiveTaste(tasteId : Long) : Taste {
+        return tasteRepository.findByIdAndStatus(tasteId, TasteStatus.ACTIVE)
+                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "${tasteId}에 맞는 취향이 존재하지 않습니다.")
     }
 }

--- a/src/main/kotlin/personaltaste/service/TasteFindService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteFindService.kt
@@ -3,22 +3,33 @@ package personaltaste.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import personaltaste.entity.model.taste.TasteStatus
+import personaltaste.exception.ExceptionCode
+import personaltaste.exception.PersonalTasteException
 import personaltaste.repository.TasteRepository
 import personaltaste.service.model.taste.TasteFind
 
 /**
- *
+ * 취향 (Taste) Entity 를 조회하는 서비스.
+ * 클래스 자체를 read Only Transaction 으로 묶었다.
  *
  * @author seungmin
  */
 @Service
+@Transactional(readOnly = true)
 class TasteFindService(
         private val tasteRepository: TasteRepository
 ) {
-    @Transactional(readOnly = true)
+
     fun findAllActive(): List<TasteFind> {
         val tastes = tasteRepository.findAllByStatusOrderByPriority(TasteStatus.ACTIVE)
 
         return tastes.map(TasteFind.Companion::ofOnlyActiveOption)
+    }
+
+    fun findOneActive(tasteId : Long) : TasteFind {
+        val taste = tasteRepository.findByIdAndStatus(tasteId, TasteStatus.ACTIVE)
+                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "${tasteId}에 맞는 취향이 존재하지 않습니다.")
+
+        return TasteFind.ofOnlyActiveOption(taste)
     }
 }

--- a/src/main/kotlin/personaltaste/service/TasteOptionWriteService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteOptionWriteService.kt
@@ -4,21 +4,19 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import personaltaste.entity.Taste
 import personaltaste.entity.TasteOption
-import personaltaste.entity.model.taste.TasteStatus
 import personaltaste.exception.ExceptionCode
 import personaltaste.exception.PersonalTasteException
 import personaltaste.repository.TasteOptionRepository
-import personaltaste.repository.TasteRepository
 
 @Service
 class TasteOptionWriteService(
-        private val tasteRepository: TasteRepository,
-        private val tasteOptionRepository: TasteOptionRepository
+        private val tasteOptionRepository: TasteOptionRepository,
+        private val tasteFindService: TasteFindService
 ) {
 
     @Transactional
     fun create(tasteId: Long, tasteOptionName: String): TasteOption {
-        val taste = this.findActiveTaste(tasteId)
+        val taste = tasteFindService.findOneActiveTaste(tasteId)
 
         if (this.checkExists(taste, tasteOptionName))
             throw PersonalTasteException(ExceptionCode.INVALID_VALUE, "중복된 취향 선택지가 존재합니다.")
@@ -28,15 +26,10 @@ class TasteOptionWriteService(
 
     @Transactional
     fun delete(tasteId: Long, tasteOptionId: Long): TasteOption {
-        val taste = this.findActiveTaste(tasteId)
+        val taste = tasteFindService.findOneActiveTaste(tasteId)
 
         return tasteOptionRepository.findByIdAndTaste(tasteOptionId, taste)?.delete()
                 ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "tasteId : $tasteId, tasteOptionId: $tasteOptionId 와 일치하는 취향 옵션이 존재하지 않습니다.")
-    }
-
-    private fun findActiveTaste(tasteId: Long): Taste {
-        return tasteRepository.findByIdAndStatus(tasteId, TasteStatus.ACTIVE)
-                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "${tasteId}에 맞는 취향이 존재하지 않습니다.")
     }
 
     private fun checkExists(taste: Taste, tasteOptionName: String): Boolean {

--- a/src/main/kotlin/personaltaste/service/TasteOptionWriteService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteOptionWriteService.kt
@@ -1,0 +1,48 @@
+package personaltaste.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import personaltaste.entity.Taste
+import personaltaste.entity.TasteOption
+import personaltaste.entity.model.taste.TasteStatus
+import personaltaste.exception.ExceptionCode
+import personaltaste.exception.PersonalTasteException
+import personaltaste.repository.TasteOptionRepository
+import personaltaste.repository.TasteRepository
+
+@Service
+class TasteOptionWriteService(
+        private val tasteRepository: TasteRepository,
+        private val tasteOptionRepository: TasteOptionRepository
+) {
+
+    @Transactional
+    fun create(tasteId: Long, tasteOptionName: String): TasteOption {
+        val taste = this.findActiveTaste(tasteId)
+
+        if (this.checkExists(taste, tasteOptionName))
+            throw PersonalTasteException(ExceptionCode.INVALID_VALUE, "중복된 취향 선택지가 존재합니다.")
+
+        return tasteOptionRepository.save(TasteOption.of(taste, tasteOptionName))
+    }
+
+    @Transactional
+    fun delete(tasteId: Long, tasteOptionId: Long): TasteOption {
+        val taste = this.findActiveTaste(tasteId)
+
+        return tasteOptionRepository.findByIdAndTaste(tasteOptionId, taste)?.delete()
+                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "tasteId : $tasteId, tasteOptionId: $tasteOptionId 와 일치하는 취향 옵션이 존재하지 않습니다.")
+    }
+
+    private fun findActiveTaste(tasteId: Long): Taste {
+        return tasteRepository.findByIdAndStatus(tasteId, TasteStatus.ACTIVE)
+                ?: throw PersonalTasteException(ExceptionCode.NOT_FOUND, "${tasteId}에 맞는 취향이 존재하지 않습니다.")
+    }
+
+    private fun checkExists(taste: Taste, tasteOptionName: String): Boolean {
+        // todo activeYn 을 일부로 조회 조건에 포함하지 않았는데, 논리삭제된 것과 동일한 entity 를 생성하려 할 때 어떻게 할 지 정해야 할 듯.
+        return tasteOptionRepository.existsByTasteAndName(taste, tasteOptionName)
+    }
+
+
+}

--- a/src/main/kotlin/personaltaste/service/TasteWriteService.kt
+++ b/src/main/kotlin/personaltaste/service/TasteWriteService.kt
@@ -10,7 +10,7 @@ import personaltaste.exception.PersonalTasteException
 import personaltaste.service.model.taste.TasteCreate
 
 /**
- *
+ * 취향(taste) Entity 생성/삭제 서비스
  *
  * @author seungmin
  */
@@ -21,7 +21,7 @@ class TasteWriteService(
 
     @Transactional
     fun create(tasteCreate: TasteCreate): Taste {
-        if (checkExists(tasteCreate.name))
+        if (this.checkExists(tasteCreate.name))
             throw PersonalTasteException(ExceptionCode.INVALID_VALUE, "동일한 취향이 이미 생성되어 있습니다.")
 
         return tasteRepository.save(tasteCreate.toTaste())

--- a/src/main/kotlin/personaltaste/service/UserCommonService.kt
+++ b/src/main/kotlin/personaltaste/service/UserCommonService.kt
@@ -22,7 +22,6 @@ class UserCommonService(
         return userRepository.save(userCreate.toUser())
     }
 
-
     fun checkExists(email: String): Boolean {
         return userRepository.existsByEmail(email)
     }

--- a/src/test/kotlin/personaltaste/controller/TasteOptionControllerTest.kt
+++ b/src/test/kotlin/personaltaste/controller/TasteOptionControllerTest.kt
@@ -1,0 +1,153 @@
+package personaltaste.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockitokotlin2.given
+import org.hamcrest.Matchers
+import org.junit.Assert.*
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import personaltaste.controller.model.taste.TasteCreateRequest
+import personaltaste.controller.model.taste.TasteOptionCreateRequest
+import personaltaste.entity.Taste
+import personaltaste.entity.TasteOption
+import personaltaste.exception.ExceptionCode
+import personaltaste.exception.PersonalTasteException
+import personaltaste.service.TasteOptionWriteService
+import personaltaste.service.model.taste.TasteCreate
+import support.test.BaseTest
+
+/**
+ * @author seungmin
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class TasteOptionControllerTest : BaseTest() {
+
+    @Autowired
+    private lateinit var snakeCaseObjectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var tasteOptionWriteService: TasteOptionWriteService
+
+    @Test
+    fun `taste option 생성 성공`() {
+        // given
+        val tasteName = "먹기"
+        val tastePriority = 1
+        val tasteId = 1L
+
+        val taste = Taste.of(
+                name = tasteName,
+                priority = tastePriority
+        )
+
+        val tasteOptionName = "찍먹"
+
+        given(tasteOptionWriteService.create(tasteId, tasteOptionName)).willReturn(TasteOption.of(taste, tasteOptionName))
+
+        // when
+        val result = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/v1/tastes/{taste_id}/options", tasteId)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .content(
+                                snakeCaseObjectMapper.writeValueAsString(
+                                        TasteOptionCreateRequest(tasteOptionName)
+                                )
+                        )
+        )
+
+        // then
+        result
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated)
+    }
+
+    @Test
+    fun `taste option 생성 실패`() {
+        // given
+        val tasteId = 1L
+        val tasteOptionName = "찍먹"
+
+        given(tasteOptionWriteService.create(tasteId, tasteOptionName)).willThrow(PersonalTasteException(ExceptionCode.INVALID_VALUE, "중복된 취향 선택지가 존재합니다."))
+
+        // when
+        val result = mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/v1/tastes/{taste_id}/options", tasteId)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .content(
+                                snakeCaseObjectMapper.writeValueAsString(
+                                        TasteOptionCreateRequest(tasteOptionName)
+                                )
+                        )
+        )
+
+        // then
+        result
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error_code", Matchers.equalTo("INVALID_VALUE")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error_message", Matchers.equalTo("${ExceptionCode.INVALID_VALUE.message} 중복된 취향 선택지가 존재합니다.")))
+    }
+
+    @Test
+    fun `taste option 삭제 성공`() {
+        // given
+        val tasteName = "먹기"
+        val tastePriority = 1
+        val tasteId = 1L
+        val tasteOptionId = 1L
+
+        val taste = Taste.of(
+                name = tasteName,
+                priority = tastePriority
+        )
+
+        val tasteOptionName = "찍먹"
+
+        given(tasteOptionWriteService.delete(tasteId, tasteOptionId)).willReturn(TasteOption.of(taste, tasteOptionName).delete())
+
+        // when
+        val result = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/v1/tastes/{taste_id}/options/{taste_option_id}", tasteId, tasteOptionId)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        )
+
+        // then
+        result
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk)
+    }
+
+    @Test
+    fun `taste option 삭제 실패`() {
+        // given
+        val tasteId = 1L
+        val tasteOptionId = 1L
+
+        given(tasteOptionWriteService.delete(tasteId, tasteOptionId)).willThrow(PersonalTasteException(ExceptionCode.NOT_FOUND, "일치하는 취향 옵션이 존재하지 않습니다."))
+
+        // when
+        val result = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/v1/tastes/{taste_id}/options/{taste_option_id}", tasteId, tasteOptionId)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        )
+
+        // then
+        result
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error_code", Matchers.equalTo("NOT_FOUND")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error_message", Matchers.equalTo("${ExceptionCode.NOT_FOUND.message} 일치하는 취향 옵션이 존재하지 않습니다.")))
+    }
+}

--- a/src/test/kotlin/personaltaste/service/TasteFindServiceTest.kt
+++ b/src/test/kotlin/personaltaste/service/TasteFindServiceTest.kt
@@ -25,7 +25,7 @@ class TasteFindServiceTest: BaseTest() {
     private lateinit var tasteFindService: TasteFindService
 
     @Test
-    fun `findAll test`() {
+    fun `findAllActive test`() {
         // given
         val eatName = "먹기"
         val eatPriority = 1
@@ -58,4 +58,26 @@ class TasteFindServiceTest: BaseTest() {
         // then
         result shouldBe tasteFindList
     }
+
+    @Test
+    fun `findOneActive test`() {
+        // given
+        val tasteName = "먹기"
+        val tastePriority = 1
+        val tasteId = 1L
+
+        val taste = Taste.of(
+                name = tasteName,
+                priority = tastePriority
+        )
+
+        given(tasteRepository.findByIdAndStatus(tasteId, TasteStatus.ACTIVE)).willReturn(taste)
+
+        // when
+        val result = tasteFindService.findOneActive(tasteId)
+
+        // then
+        result shouldBe TasteFind.ofOnlyActiveOption(taste)
+    }
+
 }

--- a/src/test/kotlin/personaltaste/service/TasteOptionWriteServiceTest.kt
+++ b/src/test/kotlin/personaltaste/service/TasteOptionWriteServiceTest.kt
@@ -1,0 +1,86 @@
+package personaltaste.service
+
+import com.nhaarman.mockitokotlin2.given
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import personaltaste.entity.Taste
+import personaltaste.entity.TasteOption
+import personaltaste.entity.User
+import personaltaste.entity.model.user.UserGender
+import personaltaste.entity.model.user.UserStatus
+import personaltaste.repository.TasteOptionRepository
+import support.test.BaseTest
+import java.util.*
+
+/**
+ * @author seungmin
+ */
+@SpringBootTest(classes = [TasteOptionWriteService::class])
+class TasteOptionWriteServiceTest: BaseTest() {
+
+    @MockBean
+    private lateinit var tasteOptionRepository: TasteOptionRepository
+
+    @MockBean
+    private lateinit var tasteFindService: TasteFindService
+
+    @Autowired
+    private lateinit var tasteOptionWriteService: TasteOptionWriteService
+
+    @Test
+    fun `create test`() {
+        // given
+        val tasteName = "먹기"
+        val tastePriority = 1
+        val tasteId = 1L
+
+        val tasteOptionName = "찍먹"
+
+        val taste = Taste.of(
+                name = tasteName,
+                priority = tastePriority
+        )
+
+        val tasteOption = TasteOption.of(taste, tasteOptionName)
+
+        given(tasteOptionRepository.existsByTasteAndName(taste, tasteOptionName)).willReturn(false)
+        given(tasteOptionRepository.save(tasteOption)).willReturn(tasteOption)
+        given(tasteFindService.findOneActiveTaste(tasteId)).willReturn(taste)
+
+        // when
+        val result = tasteOptionWriteService.create(tasteId, tasteOptionName)
+
+        // then
+        result shouldBe tasteOption
+    }
+
+    @Test
+    fun `delete test`() {
+        // given
+        val tasteName = "먹기"
+        val tastePriority = 1
+        val tasteId = 1L
+        val tasteOptionId = 2L
+
+        val tasteOptionName = "찍먹"
+
+        val taste = Taste.of(
+                name = tasteName,
+                priority = tastePriority
+        )
+
+        val tasteOption = TasteOption.of(taste, tasteOptionName)
+
+        given(tasteFindService.findOneActiveTaste(tasteId)).willReturn(taste)
+        given(tasteOptionRepository.findByIdAndTaste(tasteOptionId, taste)).willReturn(tasteOption)
+
+        // when
+        val result = tasteOptionWriteService.delete(tasteId, tasteOptionId)
+
+        // then
+        result.activeYn shouldBe false
+    }
+}

--- a/src/test/kotlin/personaltaste/service/TasteWriteServiceTest.kt
+++ b/src/test/kotlin/personaltaste/service/TasteWriteServiceTest.kt
@@ -17,7 +17,7 @@ import java.util.*
  * @author seungmin
  */
 @SpringBootTest(classes = [TasteWriteService::class])
-class TasteManageServiceTest: BaseTest() {
+class TasteWriteServiceTest: BaseTest() {
 
     @MockBean
     private lateinit var tasteRepository: TasteRepository


### PR DESCRIPTION
구현하기로 했던 취향 선택지 조회 API 는 구현하지 않았고,
부모인 Taste 단 건 조회로 확인하는 것이 맞는 것 같아서 TasteController 에 Taste 단건 조회 API 를 구현